### PR TITLE
Rebrand to Helios

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-export API_KEY=this-is-your-api-key
-export API_URL=https://api.cast.ai
+export HELIOS_API_KEY=this-is-your-api-key
+export HELIOS_API_URL=https://api.helios.example.com
 
 # Useful when agent is not running inside cluster, or instance metadata service is not available.
 export EKS_ACCOUNT_ID=your-aws-account-id

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcr.io/distroless/static-debian12:nonroot
 ARG TARGETARCH
-COPY bin/castai-agent-$TARGETARCH /usr/local/bin/castai-agent
-CMD ["castai-agent"]
+COPY bin/helios-agent-$TARGETARCH /usr/local/bin/helios-agent
+CMD ["helios-agent"]

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ fix-lint:
 	golangci-lint run ./... --fix
 
 build:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/castai-agent-amd64 .
-	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/castai-agent-arm64 .
-	docker buildx build --push --platform=linux/amd64,linux/arm64 -t  $(TAG) .
+       GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/helios-agent-amd64 .
+       GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/helios-agent-arm64 .
+       docker buildx build --push --platform=linux/amd64,linux/arm64 -t  $(TAG) .
 
 generate:
 	go generate ./...

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# CAST AI Kubernetes Agent
+# Helios Kubernetes Agent
 
-A component that connects your Kubernetes cluster to the [CAST AI](https://www.cast.ai) platform to enable Kubernetes automation and cost optimization features.
+A component that connects your Kubernetes cluster to the Helios platform to enable Kubernetes automation and cost optimization features.
 
 ## Getting started
 
-Visit the [docs](https://docs.cast.ai/docs/getting-started) to connect your cluster.
+Visit the [docs](https://docs.helios.example.com/getting-started) to connect your cluster.
 
 ## Helm chart
 
-The helm chart for the CAST AI Kubernetes agent is published in the [castai/helm-charts](https://github.com/castai/helm-charts) repo.
+The helm chart for the Helios Kubernetes agent is published in the [helios/helm-charts](https://github.com/helios/helm-charts) repo.
 
 
 ## Reading configuration from file
@@ -19,19 +19,19 @@ Example file
 ```yaml
 api:
   key: "api key"
-  url: "api.cast.ai"
+  url: "api.helios.example.com"
 ```
 or
 
 ```yaml
 api.key: "api key"
-api.url: "api.cast.ai"
+api.url: "api.helios.example.com"
 ```
 
 Shell example
 
-```shell 
-CONFIG_PATH=<PATH_TO_CONFIG> ./castai-agent
+```shell
+CONFIG_PATH=<PATH_TO_CONFIG> ./helios-agent
 ```
 
 ## Contributing
@@ -41,8 +41,8 @@ CONFIG_PATH=<PATH_TO_CONFIG> ./castai-agent
 You must provide the these environment variables:
 
 ```text
-API_KEY=your-castai-api-key
-API_URL=api.cast.ai
+HELIOS_API_KEY=your-helios-api-key
+HELIOS_API_URL=api.helios.example.com
 KUBECONFIG=/path/to/kubeconfig
 ```
 
@@ -83,7 +83,7 @@ GKE_LOCATION=your-cluster-location
 ```
 note, when using zonal `GKE_REGION` and `GKE_LOCATION` is often the same, i.e. `europe-west3-a`
 
-If you want to test changes with existing cluster already onboarded to CAST AI console, you can set environment variable 
+If you want to test changes with an existing cluster already onboarded to the Helios console, you can set the environment variable
 
 ```text
 STATIC_CLUSTER_ID=your-cluster-id
@@ -102,23 +102,23 @@ import (
 
 * Prepare a repository to work with your cluster, e.g. Google Artifact Repository if working with a GKE cluster
 * Create and push agent image with `TAG=path/to/repository/k8s-agent:1.1-your-test-tag make build`. This will build the multi-architecture agent docker image and push it to the repository of your choice. `TAG` in this case should refer to the full image path and will be used for `docker push` command as-is. Increment the version when building more test versions.
-* Clone [castai/helm-charts](https://github.com/castai/helm-charts) repo;
+* Clone [helios/helm-charts](https://github.com/helios/helm-charts) repo;
 * Add necessary changes to the chart (if needed)
 * Clone values.yaml and tweak these chart values:
   * `image.repository`: for image build above, set this to `path/to/repository/k8s-agent`
   * `image.tag`: for above example, this would be `1.1-your-test-tag`
   * `clusterVPA.enabled`: turn off for testing setups
-  * `apiURL`: override if using non-production CAST AI environment (CAST AI developers only)
+  * `apiURL`: override if using a non-production Helios environment
   * `apiKey`: API key to use for the agent
 * Deploy the chart:
   ```
-  helm template castai-agent . -n castai-agent -f values.ignore.yaml | kubectl apply -f -
+  helm template helios-agent . -n helios-agent -f values.ignore.yaml | kubectl apply -f -
   ```
   
 
 ### Release procedure (with automatic release notes)
 
-Head to the [GitHub new release page](https://github.com/castai/k8s-agent/releases/new), create a new tag at the top, and click `Generate Release Notes` at the middle-right.
+Head to the [GitHub new release page](https://github.com/helios/k8s-agent/releases/new), create a new tag at the top, and click `Generate Release Notes` at the middle-right.
 ![image](https://user-images.githubusercontent.com/571022/174777789-2d7d646d-714d-42da-8c66-a6ed407b4440.png)
 
 

--- a/cmd/agent/run.go
+++ b/cmd/agent/run.go
@@ -38,10 +38,10 @@ import (
 func run(ctx context.Context) error {
 	cfg := config.Get()
 	if cfg.API.Key == "" {
-		return errors.New("env variable \"API_KEY\" is required")
+		return errors.New("env variable \"HELIOS_API_KEY\" is required")
 	}
 	if cfg.API.URL == "" {
-		return errors.New("env variable \"API_URL\" is required")
+		return errors.New("env variable \"HELIOS_API_URL\" is required")
 	}
 
 	textFormatter := logrus.TextFormatter{FullTimestamp: true}

--- a/cmd/monitor/run.go
+++ b/cmd/monitor/run.go
@@ -17,10 +17,10 @@ import (
 func run(ctx context.Context) error {
 	cfg := config.Get()
 	if cfg.API.Key == "" {
-		return errors.New("env variable \"API_KEY\" is required")
+		return errors.New("env variable \"HELIOS_API_KEY\" is required")
 	}
 	if cfg.API.URL == "" {
-		return errors.New("env variable \"API_URL\" is required")
+		return errors.New("env variable \"HELIOS_API_URL\" is required")
 	}
 
 	remoteLogger := logrus.New()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:               "castai-agent",
+	Use:               "helios-agent",
 	PersistentPreRunE: preRun,
 }
 

--- a/internal/castai/castai.go
+++ b/internal/castai/castai.go
@@ -80,7 +80,7 @@ func NewDefaultRestyClient() (*resty.Client, error) {
 	restyClient.SetBaseURL(cfg.URL)
 	restyClient.SetRetryCount(defaultRetryCount)
 	restyClient.Header.Set(headerAPIKey, cfg.Key)
-	restyClient.Header.Set(headerUserAgent, fmt.Sprintf("castai-agent/%s", config.VersionInfo.Version))
+	restyClient.Header.Set(headerUserAgent, fmt.Sprintf("helios-agent/%s", config.VersionInfo.Version))
 	if host := cfg.HostHeaderOverride; host != "" {
 		restyClient.Header.Set("Host", host)
 	}
@@ -335,7 +335,7 @@ func addUA(header http.Header) {
 	if vi := config.VersionInfo; vi != nil {
 		version = vi.Version
 	}
-	header.Set(headerUserAgent, fmt.Sprintf("castai-agent/%s", version))
+	header.Set(headerUserAgent, fmt.Sprintf("helios-agent/%s", version))
 }
 
 func readAllString(r io.Reader) (string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,6 +174,13 @@ func Get() Config {
 		return *cfg
 	}
 
+	if val := os.Getenv("HELIOS_API_KEY"); val != "" && os.Getenv("API_KEY") == "" {
+		_ = os.Setenv("API_KEY", val)
+	}
+	if val := os.Getenv("HELIOS_API_URL"); val != "" && os.Getenv("API_URL") == "" {
+		_ = os.Setenv("API_URL", val)
+	}
+
 	viper.SetDefault("api.timeout", 10*time.Second)
 	viper.SetDefault("api.delta_read_timeout", 2*time.Minute)
 	viper.SetDefault("api.total_send_delta_timeout", 5*time.Minute)
@@ -191,11 +198,11 @@ func Get() Config {
 	viper.SetDefault("metrics_port", 9877)
 	viper.SetDefault("leader_election.enabled", true)
 	viper.SetDefault("leader_election.lock_name", "agent-leader-election-lock")
-	viper.SetDefault("leader_election.namespace", "castai-agent")
+	viper.SetDefault("leader_election.namespace", "helios-agent")
 
 	viper.SetDefault("metadata_store.enabled", false)
-	viper.SetDefault("metadata_store.config_map_name", "castai-agent-metadata")
-	viper.SetDefault("metadata_store.config_map_namespace", "castai-agent")
+	viper.SetDefault("metadata_store.config_map_name", "helios-agent-metadata")
+	viper.SetDefault("metadata_store.config_map_namespace", "helios-agent")
 
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestConfig(t *testing.T) {
 	require.NoError(t, os.Setenv("API_KEY", "abc"))
-	require.NoError(t, os.Setenv("API_URL", "api.cast.ai"))
+	require.NoError(t, os.Setenv("API_URL", "api.helios.example.com"))
 
 	require.NoError(t, os.Setenv("KUBECONFIG", "~/.kube/config"))
 
@@ -26,7 +26,7 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, cfg.LeaderElection.LockName, "agent-leader-election-lock")
 	require.Equal(t, cfg.LeaderElection.Namespace, "castai-agent")
 	require.Equal(t, "abc", cfg.API.Key)
-	require.Equal(t, "https://api.cast.ai", cfg.API.URL)
+	require.Equal(t, "https://api.helios.example.com", cfg.API.URL)
 	require.Equal(t, 6060, cfg.PprofPort)
 	require.Equal(t, "~/.kube/config", cfg.Kubeconfig)
 

--- a/internal/services/controller/controller.go
+++ b/internal/services/controller/controller.go
@@ -623,7 +623,7 @@ func (c *Controller) prepareNodesForSend(ctx context.Context, cache map[string]*
 		}
 
 		for _, spot := range spots {
-			nodesByName[spot.Name].Labels[labels.CastaiFakeSpot] = "true"
+			nodesByName[spot.Name].Labels[labels.HeliosFakeSpot] = "true"
 		}
 	}
 }

--- a/internal/services/controller/controller_test.go
+++ b/internal/services/controller/controller_test.go
@@ -549,7 +549,7 @@ func loadInitialHappyPathData(t *testing.T, scheme *runtime.Scheme) ([]sampleObj
 		},
 	}
 	expectedNode := node.DeepCopy()
-	expectedNode.Labels[labels.CastaiFakeSpot] = "true"
+	expectedNode.Labels[labels.HeliosFakeSpot] = "true"
 	nodeData := asJson(t, expectedNode)
 
 	pod := &v1.Pod{
@@ -660,7 +660,7 @@ func loadInitialHappyPathData(t *testing.T, scheme *runtime.Scheme) ([]sampleObj
 	nodePoolsDataV1 := emptyObjectData("karpenter.sh", "v1", "NodePool", "fake-nodepool-v1")
 	nodeClaimsDataV1 := emptyObjectData("karpenter.sh", "v1", "NodeClaim", "fake-nodeclaim-v1")
 	ec2NodeClassesDataV1 := emptyObjectData("karpenter.k8s.aws", "v1", "EC2NodeClass", "fake-ec2nodeclass-v1")
-	recommendationSyncV1Alpha1 := emptyObjectData("runbooks.cast.ai", "v1alpha1", "RecommendationSync", "fake-recommendationsync")
+	recommendationSyncV1Alpha1 := emptyObjectData("runbooks.helios", "v1alpha1", "RecommendationSync", "fake-recommendationsync")
 
 	datadogExtendedDSReplicaSet := &datadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
 		TypeMeta: metav1.TypeMeta{
@@ -1090,10 +1090,10 @@ func loadInitialHappyPathData(t *testing.T, scheme *runtime.Scheme) ([]sampleObj
 			},
 		},
 		{
-			GroupVersion: "runbooks.cast.ai/v1alpha1",
+			GroupVersion: "runbooks.helios/v1alpha1",
 			APIResources: []metav1.APIResource{
 				{
-					Group:   "runbooks.cast.ai",
+					Group:   "runbooks.helios",
 					Name:    "recommendationsyncs",
 					Version: "v1alpha1",
 					Kind:    "RecommendationSync",

--- a/internal/services/controller/crd/register.go
+++ b/internal/services/controller/crd/register.go
@@ -7,7 +7,7 @@ import (
 )
 
 // SchemaGroupVersion is the group version used to register these objects
-var SchemaGroupVersion = schema.GroupVersion{Group: "autoscaling.cast.ai", Version: "v1"}
+var SchemaGroupVersion = schema.GroupVersion{Group: "autoscaling.helios", Version: "v1"}
 
 // RecommendationGVR is group version resource for recommendation objects
 var RecommendationGVR = SchemaGroupVersion.WithResource("recommendations")

--- a/internal/services/controller/handlers/filters/autoscalerevents/filter.go
+++ b/internal/services/controller/handlers/filters/autoscalerevents/filter.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	AutoscalerController = "autoscaler.cast.ai"
+	AutoscalerController = "autoscaler.helios"
 	fieldSelector        = "reportingComponent=" + AutoscalerController
 )
 

--- a/internal/services/controller/handlers/transformers/annotations/transformer.go
+++ b/internal/services/controller/handlers/transformers/annotations/transformer.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	castAnnotationSuffix = "cast.ai"
+	castAnnotationSuffix = "helios"
 )
 
 var (

--- a/internal/services/controller/handlers/transformers/annotations/transformer_test.go
+++ b/internal/services/controller/handlers/transformers/annotations/transformer_test.go
@@ -46,41 +46,41 @@ func Test_Transform(t *testing.T) {
 				Annotations: map[string]string{
 					"foo.bar/baz": "qux",
 					"foo.bar/qux": "baz",
-					"cast.ai/foo": "bar",
+					"helios/foo":  "bar",
 				},
 			}},
 			expected: &v1.Pod{ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 				Annotations: map[string]string{
-					"cast.ai/foo": "bar",
+					"helios/foo": "bar",
 				},
 			}},
 		},
-		"should not remove annotation when prefix is specified but it is cast.ai annotation": {
-			prefixes: []string{"workload.cast.ai"},
+		"should not remove annotation when prefix is specified but it is helios annotation": {
+			prefixes: []string{"workload.helios"},
 			maxLen:   "",
 			input: &v1.Pod{ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"workload.cast.ai/foo": "qux",
+					"workload.helios/foo": "qux",
 				},
 			}},
 			expected: &v1.Pod{ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"workload.cast.ai/foo": "qux",
+					"workload.helios/foo": "qux",
 				},
 			}},
 		},
-		"should not strip annotation when length of value is over the limit but it is cast.ai annotation": {
-			prefixes: []string{"workload.cast.ai"},
+		"should not strip annotation when length of value is over the limit but it is helios annotation": {
+			prefixes: []string{"workload.helios"},
 			maxLen:   "2",
 			input: &v1.Pod{ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"workload.cast.ai/foo": "qux",
+					"workload.helios/foo": "qux",
 				},
 			}},
 			expected: &v1.Pod{ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"workload.cast.ai/foo": "qux",
+					"workload.helios/foo": "qux",
 				},
 			}},
 		},

--- a/internal/services/controller/knowngv/constants.go
+++ b/internal/services/controller/knowngv/constants.go
@@ -11,5 +11,5 @@ var (
 	KarpenterV1Beta1      = schema.GroupVersion{Group: "karpenter.k8s.aws", Version: "v1beta1"}
 	KarpenterV1           = schema.GroupVersion{Group: "karpenter.k8s.aws", Version: "v1"}
 
-	RunbooksV1Alpha1 = schema.GroupVersion{Group: "runbooks.cast.ai", Version: "v1alpha1"}
+	RunbooksV1Alpha1 = schema.GroupVersion{Group: "runbooks.helios", Version: "v1alpha1"}
 )

--- a/internal/services/providers/eks/aws/aws.go
+++ b/internal/services/providers/eks/aws/aws.go
@@ -142,11 +142,11 @@ func determineLifecycle(n *v1.Node) nodeLifecycle {
 		}
 	}
 
-	if val, ok := n.Labels[labels.CastaiSpotFallback]; ok && val == "true" {
+	if val, ok := n.Labels[labels.HeliosSpotFallback]; ok && val == "true" {
 		return NodeLifecycleOnDemand
 	}
 
-	if val, ok := n.Labels[labels.CastaiSpot]; ok && val == "true" {
+	if val, ok := n.Labels[labels.HeliosSpot]; ok && val == "true" {
 		return NodeLifecycleSpot
 	}
 

--- a/internal/services/providers/eks/aws/aws_test.go
+++ b/internal/services/providers/eks/aws/aws_test.go
@@ -127,7 +127,7 @@ func TestProvider_IsSpot(t *testing.T) {
 		}
 
 		node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-			labels.CastaiSpot: "true",
+			labels.HeliosSpot: "true",
 		}}}
 
 		got, err := p.FilterSpot(context.Background(), []*v1.Node{node})
@@ -213,10 +213,10 @@ func TestProvider_IsSpot(t *testing.T) {
 		}
 
 		nodeCastaiSpot := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-			labels.CastaiSpot: "true",
+			labels.HeliosSpot: "true",
 		}}}
 		nodeCastaiSpotFallback := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-			labels.CastaiSpotFallback: "true",
+			labels.HeliosSpotFallback: "true",
 		}}}
 
 		nodeKarpenterSpot := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{

--- a/internal/services/providers/gke/gke.go
+++ b/internal/services/providers/gke/gke.go
@@ -100,7 +100,7 @@ func failedAutodiscovery(err error, envVar string) error {
 }
 
 func isSpot(node *corev1.Node) bool {
-	if val, ok := node.Labels[labels.CastaiSpot]; ok && val == "true" {
+	if val, ok := node.Labels[labels.HeliosSpot]; ok && val == "true" {
 		return true
 	}
 

--- a/internal/services/providers/gke/gke_test.go
+++ b/internal/services/providers/gke/gke_test.go
@@ -85,8 +85,8 @@ func TestProvider_IsSpot(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "castai spot node",
-			node:     &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labels.CastaiSpot: "true"}}},
+			name:     "helios spot node",
+			node:     &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labels.HeliosSpot: "true"}}},
 			expected: true,
 		},
 		{

--- a/internal/services/providers/kops/kops.go
+++ b/internal/services/providers/kops/kops.go
@@ -119,7 +119,7 @@ func (p *Provider) FilterSpot(ctx context.Context, nodes []*v1.Node) ([]*v1.Node
 }
 
 func (p *Provider) isSpot(ctx context.Context, node *v1.Node) (bool, error) {
-	if val, ok := node.Labels[labels.CastaiSpot]; ok && val == "true" {
+	if val, ok := node.Labels[labels.HeliosSpot]; ok && val == "true" {
 		return true, nil
 	}
 

--- a/internal/services/providers/kops/kops_test.go
+++ b/internal/services/providers/kops/kops_test.go
@@ -176,7 +176,7 @@ func TestProvider_IsSpot(t *testing.T) {
 		node := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					labels.CastaiSpot: "true",
+					labels.HeliosSpot: "true",
 				},
 			},
 		}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,9 +1,9 @@
 package labels
 
 const (
-	CastaiSpot            = "scheduling.cast.ai/spot"
-	CastaiSpotFallback    = "scheduling.cast.ai/spot-fallback"
-	CastaiFakeSpot        = "scheduling.cast.ai/fake-spot"
+	HeliosSpot            = "scheduling.helios/spot"
+	HeliosSpotFallback    = "scheduling.helios/spot-fallback"
+	HeliosFakeSpot        = "scheduling.helios/fake-spot"
 	KopsSpot              = "spot"
 	KarpenterCapacityType = "karpenter.sh/capacity-type"
 	WorkerSpot            = "node-role.kubernetes.io/spot-worker"


### PR DESCRIPTION
## Summary
- brand agent as Helios
- update env var names and defaults
- rename k8s labels and CRD groups
- adjust documentation and build artifacts

## Testing
- `go test ./... -run TestConfig -count=1` *(fails: forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854d8e4a4ec832aa825b2998d189928